### PR TITLE
Fix TCP connection

### DIFF
--- a/lib/connection/tcp.js
+++ b/lib/connection/tcp.js
@@ -27,7 +27,7 @@ function ConnectionTCP(host, port, bucket, flush_interval) {
 		var buffer = new ByteBuffer(0);
 		buffer.writeUint32(size); // 4 byte prefix
 		buffer.writeUint8(4);  // Type
-		buffer.writeUint8(this.flush_interval);  // The Delay. Is it the 0-100 range?
+		buffer.writeUint8(self.flush_interval);  // The Delay. Is it the 0-100 range?
 		buffer.writeUint8(blen); // Size of Bucket Name
 		buffer.writeUTF8String(self.bucket); // Bucket Name
 


### PR DESCRIPTION
Tcp connections fails because it tries to create a buffer with `this.flush_interval` but in this context `this` refers to the socket (we are in an event callback related to the socket) and `this.flush_interval` is set in the `ConnectionTCP` class.

So inside the callback function, `self` should be used to access`flush_interval` , just like the line above : `buffer.writeUTF8String(self.bucket);`